### PR TITLE
daqd: Do not disable AUX I/Os during system initialization

### DIFF
--- a/src/petsys_py_lib/daqd.py
+++ b/src/petsys_py_lib/daqd.py
@@ -339,7 +339,6 @@ class Connection:
 		self.setTestPulseNone()
 		self.disableEventGate()
 		self.disableCoincidenceTrigger()
-		self.disableAuxIO()
 
 		# Set all bias to minimum
 		# Setting to zero DAC but will be saturated by mezzanine specific code


### PR DESCRIPTION
Some clients need the AUX I/O to remain on even during system initialization.