### PR TITLE
Improve throughput for 2 DAQ systems

### DIFF
--- a/src/daqd/DAQFrameServer.cpp
+++ b/src/daqd/DAQFrameServer.cpp
@@ -264,6 +264,7 @@ void *DAQFrameServer::doWork()
 				frameID0 = tmp0[0] & 0xFFFFFFFFFULL;
 				frameID1 = tmp1[0] & 0xFFFFFFFFFULL;
 				//fprintf(stderr, "D1 %016llx %016llx\n", frameID0, frameID1);
+				if(frameID0 == frameID1) break;
 
 				if(frameID0 < frameID1) tmp0 = cards[0]->getNextFrame();
 				if(frameID1 < frameID0) tmp1 = cards[1]->getNextFrame();

--- a/src/petsys_py_lib/daqd.py
+++ b/src/petsys_py_lib/daqd.py
@@ -1188,9 +1188,13 @@ class Connection:
 		nFrames = 0
 		lastUpdateFrame = currentFrame
 		while currentFrame < stopFrame:
-			wrPointer, rdPointer = self.__getDataFrameWriteReadPointer()
-			while wrPointer == rdPointer:
+			try:
 				wrPointer, rdPointer = self.__getDataFrameWriteReadPointer()
+				while wrPointer == rdPointer:
+					wrPointer, rdPointer = self.__getDataFrameWriteReadPointer()
+			except ErrorAcquisitionStopped as e:
+				# Acquisition must have been stopped by a different program
+				break
 
 			nFramesInBlock = abs(wrPointer - rdPointer)
 			if nFramesInBlock > bs:


### PR DESCRIPTION
Add a code path for the common case where frameID are already synchronized between both DAQ cards.