### PR TITLE
Fix DAQ card driver installation for Ubuntu and kernel > 6.3

### DIFF
--- a/INSTALL_DRIVERS.sh
+++ b/INSTALL_DRIVERS.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-find /lib/modules -name psdaq.ko.xz | xargs rm
+find /lib/modules -name psdaq.ko -or -name psdaq.ko.xz | xargs rm
 rm -rf /var/lib/dkms/psdaq
 modprobe -r psdaq
 

--- a/src/kernel/psdaq.c
+++ b/src/kernel/psdaq.c
@@ -121,7 +121,12 @@ static int __init psdaq_init(void)
 {
 	int err;
 
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 3, 0)
+	psdaq_dev_class = class_create("psdaq");
+#else
 	psdaq_dev_class = class_create(THIS_MODULE, "psdaq");
+#endif
+
 	if (IS_ERR(psdaq_dev_class)) {
 		err = PTR_ERR(psdaq_dev_class);
 		return err;


### PR DESCRIPTION
* Ubuntu does not compress kernel modules with .xz so old modules were not being deleted by the install script
* Kernel 6.4 changed the API for class_create