### PR TITLE
Acquisition start options

### DIFF
--- a/src/base/DataFileWriter.cpp
+++ b/src/base/DataFileWriter.cpp
@@ -210,7 +210,7 @@ void DataFileWriter::renameFile() {
 };
 
 
-void DataFileWriter::writeRawEvents(EventBuffer<RawHit> *buffer) {
+void DataFileWriter::writeRawEvents(EventBuffer<RawHit> *buffer, double t0) {
     
     long long filePartIndex = (int)floor(buffer->getTMin() / fileSplitTime);
     checkFilePartForSplit(filePartIndex);
@@ -250,12 +250,12 @@ void DataFileWriter::writeRawEvents(EventBuffer<RawHit> *buffer) {
 }
 
 
-void DataFileWriter::writeSingleEvents(EventBuffer<Hit> *buffer) {
+void DataFileWriter::writeSingleEvents(EventBuffer<Hit> *buffer, double t0) {
     
     long long filePartIndex = (int)floor(buffer->getTMin() / fileSplitTime);
     checkFilePartForSplit(filePartIndex);
     
-    long long tMin = buffer->getTMin() * (long long)Tps;
+    long long tMin = (buffer->getTMin() + t0) * (long long)Tps;
 
     int N = buffer->getSize();
     for (int i = 0; i < N; i++) {
@@ -305,11 +305,11 @@ void DataFileWriter::writeSingleEvents(EventBuffer<Hit> *buffer) {
     }	
 }
 
-void DataFileWriter::writeGroupEvents(EventBuffer<GammaPhoton> *buffer) {
+void DataFileWriter::writeGroupEvents(EventBuffer<GammaPhoton> *buffer, double t0) {
     long long filePartIndex = (int)floor(buffer->getTMin() / fileSplitTime);
     checkFilePartForSplit(filePartIndex);
 
-    long long tMin = buffer->getTMin() * (long long)Tps;
+    long long tMin = (buffer->getTMin() + t0) * (long long)Tps;
     
     int N = buffer->getSize();
     for (int i = 0; i < N; i++) {
@@ -394,11 +394,11 @@ void DataFileWriter::writeGroupEvents(EventBuffer<GammaPhoton> *buffer) {
 }
 
 
-void DataFileWriter::writeCoincidenceEvents(EventBuffer<Coincidence> *buffer) {
+void DataFileWriter::writeCoincidenceEvents(EventBuffer<Coincidence> *buffer, double t0) {
     long long filePartIndex = (int)floor(buffer->getTMin() / fileSplitTime);
     checkFilePartForSplit(filePartIndex);
 
-    long long tMin = buffer->getTMin() * (long long)Tps;
+    long long tMin = (buffer->getTMin() + t0) * (long long)Tps;
     
     int N = buffer->getSize();
     for (int i = 0; i < N; i++) {

--- a/src/base/DataFileWriter.hpp
+++ b/src/base/DataFileWriter.hpp
@@ -129,10 +129,10 @@ public:
 	void checkFilePartForSplit(long long filePartIndex);
 	void closeStep();
 	void renameFile(); 
-	void writeRawEvents(EventBuffer<RawHit> *buffer);	
-    void writeSingleEvents(EventBuffer<Hit> *buffer);
-    void writeGroupEvents(EventBuffer<GammaPhoton> *buffer);
-	void writeCoincidenceEvents(EventBuffer<Coincidence> *buffer);
+	void writeRawEvents(EventBuffer<RawHit> *buffer, double t0);
+	void writeSingleEvents(EventBuffer<Hit> *buffer, double t0);
+	void writeGroupEvents(EventBuffer<GammaPhoton> *buffer, double t0);
+	void writeCoincidenceEvents(EventBuffer<Coincidence> *buffer, double t0);
 };
 
 
@@ -147,7 +147,7 @@ public:
 	};
 	
 	EventBuffer<RawHit> * handleEvents(EventBuffer<RawHit> *buffer) {
-		dataFileWriter->writeRawEvents(buffer);
+		dataFileWriter->writeRawEvents(buffer, getT0());
 		return buffer;
 	};
 };
@@ -164,7 +164,7 @@ public:
 	};
 
 	EventBuffer<Hit> * handleEvents(EventBuffer<Hit> *buffer) {
-		dataFileWriter->writeSingleEvents(buffer);
+		dataFileWriter->writeSingleEvents(buffer, getT0());
 		return buffer;
 	};
 };
@@ -181,7 +181,7 @@ public:
 	};
 	
 	EventBuffer<GammaPhoton> * handleEvents(EventBuffer<GammaPhoton> *buffer) {
-		dataFileWriter->writeGroupEvents(buffer);
+		dataFileWriter->writeGroupEvents(buffer, getT0());
 		return buffer;
 	};
 };
@@ -199,7 +199,7 @@ public:
 	};
 
 	EventBuffer<Coincidence> * handleEvents(EventBuffer<Coincidence> *buffer) {
-		dataFileWriter->writeCoincidenceEvents(buffer);
+		dataFileWriter->writeCoincidenceEvents(buffer, getT0());
 		return buffer;
 	};
 };        

--- a/src/base/OrderedEventHandler.hpp
+++ b/src/base/OrderedEventHandler.hpp
@@ -24,6 +24,7 @@ namespace PETSYS {
 		};
 		
 		virtual void pushT0(double t0) {
+			this->t0 = t0;
 			this->sink->pushT0(t0);
 		};
 		
@@ -68,12 +69,14 @@ namespace PETSYS {
 		};
 		
 	protected:
-		virtual EventBuffer<TEventOutput> * handleEvents(EventBuffer<TEventInput> *inBuffer) = 0;		
+		virtual EventBuffer<TEventOutput> * handleEvents(EventBuffer<TEventInput> *inBuffer) = 0;
+		double getT0() { return t0; };
 
 	private:
 		u_int64_t expectedSeqN;
 		pthread_mutex_t lock;
 		std::map<size_t, pthread_cond_t *> queue;
+		double t0;
 		
 	};
 

--- a/src/petsys_py_lib/daqd.py
+++ b/src/petsys_py_lib/daqd.py
@@ -21,7 +21,7 @@ import math
 import subprocess
 from sys import stdout
 from copy import deepcopy
-import os
+import os, stat
 
 MAX_PORTS = 32
 MAX_SLAVES = 32
@@ -1050,6 +1050,16 @@ class Connection:
 		
 		# Cache max values after applying
 		self.__hvdac_max_values = max_value.copy()
+
+
+	def waitOnNamedPipe(self, fn):
+		if not stat.S_ISFIFO(os.stat(fn).st_mode):
+			raise Exception("'%s' is not a FIFO" % fn)
+		print("Waiting for a byte to be written to '%s'" % fn)
+		f = open(fn, 'r')
+		d = f.read(1)
+		f.close()
+		return None
 
 	def openRawAcquisition(self, fileNamePrefix, calMode = False):
 		return self.__openRawAcquisition(fileNamePrefix, calMode, None, None, None)

--- a/src/petsys_py_lib/daqd.py
+++ b/src/petsys_py_lib/daqd.py
@@ -1093,12 +1093,19 @@ class Connection:
 		else:
 			portID, slaveID = trigger
 			triggerID = 32 * portID + slaveID
+  		
+
+		# Determine current time and and estimate acquisition wallclock start time
+		fileCreationDAQTime = self.getCurrentTimeTag()
+		currentTime = time()
+		daqSynchronizationEpoch = currentTime - fileCreationDAQTime / self.__systemFrequency
 		
 		cmd = [ "./write_raw", \
 			self.__shmName, \
 			fileNamePrefix, \
 			str(int(self.__systemFrequency)), \
-			str(qdcMode), "%1.12f" % self.getAcquisitionStartTime(),
+			str(qdcMode), "%1.12f" % daqSynchronizationEpoch,
+			str(fileCreationDAQTime),
 			calMode and 'T' or 'N', 
 			str(triggerID) ]
 		self.__writerPipe = subprocess.Popen(cmd, bufsize=1, stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
@@ -1112,7 +1119,7 @@ class Connection:
 				self.__shmName,
 				monitor_toc,
 				str(triggerID), 
-				"%1.12f" % self.getAcquisitionStartTime()
+				"%1.12f" % daqSynchronizationEpoch
 				]
 			self.__monitorPipe = subprocess.Popen(cmd, bufsize=1, stdin=subprocess.PIPE, stdout=subprocess.PIPE, close_fds=True)
 
@@ -1149,6 +1156,7 @@ class Connection:
 			
 		frameLength = 1024.0 / self.__systemFrequency
 		nRequiredFrames = int(acquisitionTime / frameLength)
+		nRequiredFrames = max(nRequiredFrames, 1) # Attempt to acquire at least 1 frame
 
 		template1 = "@ffIIi"
 		template2 = "@I"
@@ -1168,20 +1176,6 @@ class Connection:
 		stopFrame = startFrame + nRequiredFrames
 
 		t0 = time()
-
-		# Send start of step block (with wrPointer = rdPointer)
-		data = struct.pack(template1, step1, step2, rdPointer, rdPointer, 0)
-		for pin, pout in workers:
-			pin.write(data); pin.flush()
-
-		for pin, pout in workers:
-			data = pout.read(n2)
-		rdPointer,  = struct.unpack(template2, data)
-		self.__setDataFrameReadPointer(rdPointer)
-
-		for pin, pout in workers:
-			data = pout.read(n3)
-		stepFrames, stepFramesLost, stepEvents = struct.unpack(template3, data)
 
 		nBlocks = 0
 		currentFrame = startFrame
@@ -1215,7 +1209,12 @@ class Connection:
 
 			wrPointer = (rdPointer + nFramesInBlock) % (2*bs)
 
-			data = struct.pack(template1, step1, step2, wrPointer, rdPointer, 1)
+			if nBlocks == 0:
+				# First block in step
+				data = struct.pack(template1, step1, step2, wrPointer, rdPointer, 0)
+			else:
+				# Other blocks in step
+				data = struct.pack(template1, step1, step2, wrPointer, rdPointer, 1)
 			for pin, pout in workers:
 				pin.write(data); pin.flush()
 			
@@ -1496,13 +1495,6 @@ class Connection:
 				raise ErrorNoFEB()
 
 		return self.read_config_register(portID, 0, 46, 0x0203)
-
-
-	def getAcquisitionStartTime(self):
-		currentTimeTag = self.getCurrentTimeTag()
-		currentTime = time()
-		return currentTime - currentTimeTag / self.__systemFrequency
-
 
 		
 	## Returns a 3 element tupple with the number of transmitted, received, and error packets for a given port 

--- a/src/petsys_util/acquire_sipm_data
+++ b/src/petsys_util/acquire_sipm_data
@@ -10,115 +10,122 @@ import math
 import time
 
 
-parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
-parser.add_argument("--config", type=str, required=True, help="Configuration file")
-parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help = "Data filename (prefix)")
-parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
-parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help = "Acquisition mode (tot, qdc or mixed)")
-parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
-parser.add_argument("--param-table", type=str, dest="paramTable", help="Table containing the name and values of 1 or 2 parameters to be scanned during data acquisition. Allowed parameters are: OV (SIPM Overvoltage), vth_t1 (t1 discriminator threshold, in DAC units relative to the channel baseline), vth_t2 (t2 discriminator threshold, in DAC units relative to the channel baseline), vth_e (e discriminator threshold, in DAC units relative to the channel baseline), disc_lsb_t1 (t1 discriminator DAC LSB)")
-
-args = parser.parse_args()
-
-validParams = ["OV","vth_t1","vth_t2","vth_e","disc_lsb_t1"]
-
-if args.paramTable is not None:
-        if not os.path.exists(args.paramTable):
-                print("Error: no such file - %s" % args.paramTable)
-                exit(1)
-        table = pandas.read_table(args.paramTable)
-        parNames = list(table)
-        for name in parNames:
-                if name not in validParams:
-                        print(("Error: Invalid parameter - %s" % name))
-                        exit(1)
-                        
-        step1Values = list(table[parNames[0]])
-        if len(parNames) == 2:
-                step2Values = list(table[parNames[1]])
-        elif len(parNames) == 1:
-                step2Values = [0]
-                parNames.append("none")
-        else:
-                print("Error: only two parameters can be scanned at the same time") 
-                exit(1)
- 
-    
-mask = config.LOAD_ALL
-if args.mode != "mixed":
-        mask ^= config.LOAD_QDCMODE_MAP
-systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
-
-daqd = daqd.Connection()
-daqd.initializeSystem()
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
-
-daqd.openRawAcquisition(args.fileNamePrefix)
+def main():
+	parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
+	parser.add_argument("--config", type=str, required=True, help="Configuration file")
+	parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help = "Data filename (prefix)")
+	parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
+	parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help = "Acquisition mode (tot, qdc or mixed)")
+	parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
+	parser.add_argument("--param-table", type=str, dest="paramTable", help="Table containing the name and values of 1 or 2 parameters to be scanned during data acquisition. Allowed parameters are: OV (SIPM Overvoltage), vth_t1 (t1 discriminator threshold, in DAC units relative to the channel baseline), vth_t2 (t2 discriminator threshold, in DAC units relative to the channel baseline), vth_e (e discriminator threshold, in DAC units relative to the channel baseline), disc_lsb_t1 (t1 discriminator DAC LSB)")
+	parser.add_argument("--wait-on", dest="waitOn", type=str, help="Wait on named pipe before acquiring data")
 
 
-activeAsics = daqd.getActiveAsics()
-activeChannels = [ (portID, slaveID, chipID, channelID) for channelID in range(64) for portID, slaveID, chipID in activeAsics ]
+	args = parser.parse_args()
 
-asicsConfig = daqd.getAsicsConfig()
+	validParams = ["OV","vth_t1","vth_t2","vth_e","disc_lsb_t1"]
 
-if args.paramTable is None:
-        daqd.acquire(args.time, 0, 0)
-else:
-        for step1 in step1Values:
-                step1 = float(step1)
-                if math.isnan(step1):
-                        continue 
-                if parNames[0] in ['vth_t1', 'vth_t2', 'vth_e']:
-                        for portID, slaveID, chipID, channelID in activeChannels:
-                                cc = asicsConfig[(portID, slaveID, chipID)].channelConfig[channelID]
-                                dac_setting = systemConfig.mapAsicChannelThresholdToDAC((portID, slaveID, chipID, channelID), parNames[0], int(step1))
-                                cc.setValue(parNames[0], dac_setting)
-                elif parNames[0] in ['disc_lsb_t1']:
-                        for portID, slaveID, chipID in activeAsics:
-                                cc = asicsConfig[(portID, slaveID, chipID)].globalConfig
-                                cc.setValue(parNames[0], int(step1))
-                elif parNames[0] in ['OV']:
-                        biasVoltageConfig = daqd.get_hvdac_config()
-                        for key in daqd.getActiveBiasChannels():
-                                offset, prebd, bd, over__ = systemConfig.getBiasChannelDefaultSettings(key)
-                                vset = offset + bd + step1
-                                dac_setting = systemConfig.mapBiasChannelVoltageToDAC(key, vset)
-                                biasVoltageConfig[key] = dac_setting
-                                daqd.set_hvdac_config(biasVoltageConfig)
-                daqd.setAsicsConfig(asicsConfig)       
-              
-                for step2 in step2Values:
-                        step2 = float(step2)
-                        if math.isnan(step2):
-                                continue 
-                        if parNames[1] in ['vth_t1', 'vth_t2', 'vth_e']:
-                                for portID, slaveID, chipID, channelID in activeChannels:
-                                        cc = asicsConfig[(portID, slaveID, chipID)].channelConfig[channelID]
-                                        dac_setting = systemConfig.mapAsicChannelThresholdToDAC((portID, slaveID, chipID, channelID), parNames[1], int(step2))
-                                        cc.setValue(parNames[1], dac_setting)
-                        elif parNames[1] in ['disc_lsb_t1']:
-                                for portID, slaveID, chipID in activeAsics:
-                                        cc = asicsConfig[(portID, slaveID, chipID)].globalConfig
-                                        cc.setValue(parNames[1], int(step2))
-                        elif parNames[1] in ['OV']:
-                                #step2 = step2_
-                                biasVoltageConfig = daqd.get_hvdac_config()
-                                for key in daqd.getActiveBiasChannels():
-                                        offset, prebd, bd, over__ = systemConfig.getBiasChannelDefaultSettings(key)
-                                        vset = offset + bd + step2
-                                        dac_setting = systemConfig.mapBiasChannelVoltageToDAC(key, vset)
-                                        biasVoltageConfig[key] = dac_setting
-                                daqd.set_hvdac_config(biasVoltageConfig)
-                
-                        if parNames[1] == "none":
-                                print("Python:: Acquiring data for: " + parNames[0] + " = " + str(step1)) 
-                        else:
-                                print("Python:: Acquiring data for: " + parNames[0] + " = " + str(step1) + " ; " + parNames[1] + " = " + str(step2))  
-                        daqd.setAsicsConfig(asicsConfig)
-                        daqd.acquire(args.time, float(step1), float(step2))   
-                    
+	if args.paramTable is not None:
+		if not os.path.exists(args.paramTable):
+			print("Error: no such file - %s" % args.paramTable)
+			exit(1)
+		table = pandas.read_table(args.paramTable)
+		parNames = list(table)
+		for name in parNames:
+			if name not in validParams:
+				print(("Error: Invalid parameter - %s" % name))
+				exit(1)
+
+		step1Values = list(table[parNames[0]])
+		if len(parNames) == 2:
+			step2Values = list(table[parNames[1]])
+		elif len(parNames) == 1:
+			step2Values = [0]
+			parNames.append("none")
+		else:
+			print("Error: only two parameters can be scanned at the same time")
+			exit(1)
 
 
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_OFF)
+	mask = config.LOAD_ALL
+	if args.mode != "mixed":
+		mask ^= config.LOAD_QDCMODE_MAP
+	systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
+
+	conn = daqd.Connection()
+	conn.initializeSystem()
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
+
+	if args.waitOn:
+		conn.waitOnNamedPipe(args.waitOn)
+	conn.openRawAcquisition(args.fileNamePrefix)
 
 
+	activeAsics = conn.getActiveAsics()
+	activeChannels = [ (portID, slaveID, chipID, channelID) for channelID in range(64) for portID, slaveID, chipID in activeAsics ]
+
+	asicsConfig = conn.getAsicsConfig()
+
+	if args.paramTable is None:
+		conn.acquire(args.time, 0, 0)
+	else:
+		for step1 in step1Values:
+			step1 = float(step1)
+			if math.isnan(step1):
+				continue
+			if parNames[0] in ['vth_t1', 'vth_t2', 'vth_e']:
+				for portID, slaveID, chipID, channelID in activeChannels:
+					cc = asicsConfig[(portID, slaveID, chipID)].channelConfig[channelID]
+					dac_setting = systemConfig.mapAsicChannelThresholdToDAC((portID, slaveID, chipID, channelID), parNames[0], int(step1))
+					cc.setValue(parNames[0], dac_setting)
+			elif parNames[0] in ['disc_lsb_t1']:
+				for portID, slaveID, chipID in activeAsics:
+					cc = asicsConfig[(portID, slaveID, chipID)].globalConfig
+					cc.setValue(parNames[0], int(step1))
+			elif parNames[0] in ['OV']:
+				biasVoltageConfig = conn.get_hvdac_config()
+				for key in conn.getActiveBiasChannels():
+					offset, prebd, bd, over__ = systemConfig.getBiasChannelDefaultSettings(key)
+					vset = offset + bd + step1
+					dac_setting = systemConfig.mapBiasChannelVoltageToDAC(key, vset)
+					biasVoltageConfig[key] = dac_setting
+					conn.set_hvdac_config(biasVoltageConfig)
+			conn.setAsicsConfig(asicsConfig)
+
+			for step2 in step2Values:
+				step2 = float(step2)
+				if math.isnan(step2):
+					continue
+				if parNames[1] in ['vth_t1', 'vth_t2', 'vth_e']:
+					for portID, slaveID, chipID, channelID in activeChannels:
+						cc = asicsConfig[(portID, slaveID, chipID)].channelConfig[channelID]
+						dac_setting = systemConfig.mapAsicChannelThresholdToDAC((portID, slaveID, chipID, channelID), parNames[1], int(step2))
+						cc.setValue(parNames[1], dac_setting)
+				elif parNames[1] in ['disc_lsb_t1']:
+					for portID, slaveID, chipID in activeAsics:
+						cc = asicsConfig[(portID, slaveID, chipID)].globalConfig
+						cc.setValue(parNames[1], int(step2))
+				elif parNames[1] in ['OV']:
+					#step2 = step2_
+					biasVoltageConfig = conn.get_hvdac_config()
+					for key in conn.getActiveBiasChannels():
+						offset, prebd, bd, over__ = systemConfig.getBiasChannelDefaultSettings(key)
+						vset = offset + bd + step2
+						dac_setting = systemConfig.mapBiasChannelVoltageToDAC(key, vset)
+						biasVoltageConfig[key] = dac_setting
+					conn.set_hvdac_config(biasVoltageConfig)
+
+				if parNames[1] == "none":
+					print("Python:: Acquiring data for: " + parNames[0] + " = " + str(step1))
+				else:
+					print("Python:: Acquiring data for: " + parNames[0] + " = " + str(step1) + " ; " + parNames[1] + " = " + str(step2))
+				conn.setAsicsConfig(asicsConfig)
+				conn.acquire(args.time, float(step1), float(step2))
+
+
+
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_OFF)
+	return 0
+
+if __name__ == '__main__':
+	exit(main())

--- a/src/petsys_util/acquire_sipm_data_basic
+++ b/src/petsys_util/acquire_sipm_data_basic
@@ -5,24 +5,32 @@ from petsys import daqd, config
 from copy import deepcopy
 import argparse
 
-parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
-parser.add_argument("--config", type=str, required=True, help="Configuration file")
-parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help="Data filename (prefix)")
-parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
-parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help="Acquisition mode (tot, qdc or mixed)")
-parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
-args = parser.parse_args()
+def main():
+	parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
+	parser.add_argument("--config", type=str, required=True, help="Configuration file")
+	parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help="Data filename (prefix)")
+	parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
+	parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help="Acquisition mode (tot, qdc or mixed)")
+	parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
+	parser.add_argument("--wait-on", dest="waitOn", type=str, help="Wait on named pipe before acquiring data")
+	args = parser.parse_args()
 
-mask = config.LOAD_ALL
-if args.mode != "mixed":
-        mask ^= config.LOAD_QDCMODE_MAP
-systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
+	mask = config.LOAD_ALL
+	if args.mode != "mixed":
+		mask ^= config.LOAD_QDCMODE_MAP
+	systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
 
-daqd = daqd.Connection()
-daqd.initializeSystem()
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
+	conn = daqd.Connection()
+	conn.initializeSystem()
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
 
-daqd.openRawAcquisition(args.fileNamePrefix)
-daqd.acquire(args.time, 0, 0);
+	if args.waitOn:
+		conn.waitOnNamedPipe(args.waitOn)
+	conn.openRawAcquisition(args.fileNamePrefix)
+	conn.acquire(args.time, 0, 0);
 
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_OFF)
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_OFF)
+	return 0
+        
+if __name__  == '__main__':
+        exit(main())

--- a/src/petsys_util/acquire_sipm_data_with_monitoring
+++ b/src/petsys_util/acquire_sipm_data_with_monitoring
@@ -5,25 +5,33 @@ from petsys import daqd, config
 from copy import deepcopy
 import argparse
 
-parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
-parser.add_argument("--config", type=str, required=True, help="Configuration file")
-parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help="Data filename (prefix)")
-parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
-parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help="Acquisition mode (tot, qdc or mixed)")
-parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
-parser.add_argument("--monitor-toc", dest="monitor_toc", type=str, required=True, help="Monitor TOC")
-args = parser.parse_args()
+def main():
+	parser = argparse.ArgumentParser(description='Acquire data for TDC calibration')
+	parser.add_argument("--config", type=str, required=True, help="Configuration file")
+	parser.add_argument("-o", type=str, dest="fileNamePrefix", required=True, help="Data filename (prefix)")
+	parser.add_argument("--time", type=float, required=True, help="Acquisition time (in seconds)")
+	parser.add_argument("--mode", type=str, required=True, choices=["tot", "qdc", "mixed"], help="Acquisition mode (tot, qdc or mixed)")
+	parser.add_argument("--enable-hw-trigger", dest="hwTrigger", action="store_true", help="Enable the hardware coincidence filter")
+	parser.add_argument("--monitor-toc", dest="monitor_toc", type=str, required=True, help="Monitor TOC")
+	parser.add_argument("--wait-on", dest="waitOn", type=str, help="Wait on named pipe before acquiring data")
+	args = parser.parse_args()
 
-mask = config.LOAD_ALL
-if args.mode != "mixed":
-        mask ^= config.LOAD_QDCMODE_MAP
-systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
+	mask = config.LOAD_ALL
+	if args.mode != "mixed":
+		mask ^= config.LOAD_QDCMODE_MAP
+	systemConfig = config.ConfigFromFile(args.config, loadMask=mask)
 
-daqd = daqd.Connection()
-daqd.initializeSystem()
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
+	conn = daqd.Connection()
+	conn.initializeSystem()
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_ON, hw_trigger_enable=args.hwTrigger, qdc_mode = args.mode)
 
-daqd.openRawAcquisitionWithMonitor(args.fileNamePrefix, monitor_config=args.config, monitor_toc=args.monitor_toc)
-daqd.acquire(args.time, 0, 0);
+	if args.waitOn:
+		conn.waitOnNamedPipe(args.waitOn)
+	conn.openRawAcquisitionWithMonitor(args.fileNamePrefix, monitor_config=args.config, monitor_toc=args.monitor_toc)
+	conn.acquire(args.time, 0, 0);
 
-systemConfig.loadToHardware(daqd, bias_enable=config.APPLY_BIAS_OFF)
+	systemConfig.loadToHardware(conn, bias_enable=config.APPLY_BIAS_OFF)
+	return 0
+
+if __name__ == '__main__':
+	exit(main())

--- a/src/petsys_util/convert_raw_to_coincidence.cpp
+++ b/src/petsys_util/convert_raw_to_coincidence.cpp
@@ -32,7 +32,7 @@ void displayHelp(char * program)
 	fprintf(stderr,  "  --writeMultipleHits N \t\t Writes multiple hits, up to the Nth hit\n");
 	fprintf(stderr,  "  --writeFraction N \t\t Fraction of events to write. Default: 100%%.\n");
 	fprintf(stderr,  "  --splitTime t \t\t Split output into different files every t seconds.\n");
-	fprintf(stderr,  "  --timebase [sync|wall|step|user] \t\t Select timebase for written data\n");
+	fprintf(stderr,  "  --timeref [sync|wall|step|user] \t\t Select timeref for written data\n");
 	fprintf(stderr,  "  --help \t\t Show this help message and exit \n");
 };
 
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 	int hitLimitToWrite = 1;
 	long long eventFractionToWrite = 1024;
 	double fileSplitTime = 0;
-	RawReader::timebase_t tb = RawReader::SYNC;
+	RawReader::timeref_t tb = RawReader::SYNC;
 
 	static struct option longOptions[] = {
 		{ "help", no_argument, 0, 0 },
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
 		{ "writeMultipleHits", required_argument, 0, 0},
 		{ "writeFraction", required_argument },
 		{ "splitTime", required_argument, 0, 0},
-		{ "timebase", required_argument, 0, 0}
+		{ "timeref", required_argument, 0, 0}
     };
 
 	while(true) {
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 					else if(strcmp(optarg, "wall") == 0) tb = RawReader::WALL;
 					else if(strcmp(optarg, "step") == 0) tb = RawReader::STEP;
 					else if(strcmp(optarg, "user") == 0) tb = RawReader::USER;
-					else { fprintf(stderr, "ERROR: unkown timebase '%s'\n", optarg); exit(1); }
+					else { fprintf(stderr, "ERROR: unkown timeref '%s'\n", optarg); exit(1); }
 					break;
 
 			default:	displayUsage(argv[0]); exit(1);

--- a/src/petsys_util/convert_raw_to_group.cpp
+++ b/src/petsys_util/convert_raw_to_group.cpp
@@ -32,7 +32,7 @@ void displayHelp(char * program)
 	fprintf(stderr,  "  --writeMultipleHits N \t\t Writes multiple hits, up to the Nth hit\n");
 	fprintf(stderr,  "  --writeFraction N \t\t Fraction of events to write. Default: 100%%.\n");
 	fprintf(stderr,  "  --splitTime t \t\t Split output into different files every t seconds.\n");
-	fprintf(stderr,  "  --timebase [sync|wall|step|user] \t\t Select timebase for written data\n");
+	fprintf(stderr,  "  --timeref [sync|wall|step|user] \t\t Select timeref for written data\n");
 	fprintf(stderr,  "  --help \t\t Show this help message and exit \n");
 	
 };
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 	int hitLimitToWrite = 1;
 	long long eventFractionToWrite = 1024;
 	double fileSplitTime = 0.0;
-	RawReader::timebase_t tb = RawReader::SYNC;
+	RawReader::timeref_t tb = RawReader::SYNC;
 
 	static struct option longOptions[] = {
 		{ "help", no_argument, 0, 0 },
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 		{ "writeMultipleHits", required_argument, 0, 0},
 		{ "writeFraction", required_argument, 0, 0},
 		{ "splitTime", required_argument, 0, 0},
-		{ "timebase", required_argument, 0, 0}
+		{ "timeref", required_argument, 0, 0}
 	};
 
 	while(true) {
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 					else if(strcmp(optarg, "wall") == 0) tb = RawReader::WALL;
 					else if(strcmp(optarg, "step") == 0) tb = RawReader::STEP;
 					else if(strcmp(optarg, "user") == 0) tb = RawReader::USER;
-					else { fprintf(stderr, "ERROR: unkown timebase '%s'\n", optarg); exit(1); }
+					else { fprintf(stderr, "ERROR: unkown timeref '%s'\n", optarg); exit(1); }
 					break;
 
 			default:	displayUsage(argv[0]); exit(1);

--- a/src/petsys_util/convert_raw_to_group.cpp
+++ b/src/petsys_util/convert_raw_to_group.cpp
@@ -32,6 +32,7 @@ void displayHelp(char * program)
 	fprintf(stderr,  "  --writeMultipleHits N \t\t Writes multiple hits, up to the Nth hit\n");
 	fprintf(stderr,  "  --writeFraction N \t\t Fraction of events to write. Default: 100%%.\n");
 	fprintf(stderr,  "  --splitTime t \t\t Split output into different files every t seconds.\n");
+	fprintf(stderr,  "  --timebase [sync|wall|step|user] \t\t Select timebase for written data\n");
 	fprintf(stderr,  "  --help \t\t Show this help message and exit \n");
 	
 };
@@ -45,12 +46,13 @@ void displayUsage(char *argv0)
 int main(int argc, char *argv[])
 {
 	char *configFileName = NULL;
-    char *inputFilePrefix = NULL;
-    char *outputFileName = NULL;
+	char *inputFilePrefix = NULL;
+	char *outputFileName = NULL;
 	FILE_TYPE fileType = FILE_TEXT;
 	int hitLimitToWrite = 1;
 	long long eventFractionToWrite = 1024;
 	double fileSplitTime = 0.0;
+	RawReader::timebase_t tb = RawReader::SYNC;
 
 	static struct option longOptions[] = {
 		{ "help", no_argument, 0, 0 },
@@ -61,7 +63,8 @@ int main(int argc, char *argv[])
 		{ "writeBinaryCompact", no_argument, 0, 0 },
 		{ "writeMultipleHits", required_argument, 0, 0},
 		{ "writeFraction", required_argument, 0, 0},
-		{ "splitTime", required_argument, 0, 0}
+		{ "splitTime", required_argument, 0, 0},
+		{ "timebase", required_argument, 0, 0}
 	};
 
 	while(true) {
@@ -88,6 +91,14 @@ int main(int argc, char *argv[])
 			case 6:		hitLimitToWrite = boost::lexical_cast<int>(optarg); break;
 			case 7:		eventFractionToWrite = round(1024 *boost::lexical_cast<float>(optarg) / 100.0); break;
 			case 8:		fileSplitTime = boost::lexical_cast<double>(optarg); break;
+
+			case 9:		if(strcmp(optarg, "sync") == 0) tb = RawReader::SYNC;
+					else if(strcmp(optarg, "wall") == 0) tb = RawReader::WALL;
+					else if(strcmp(optarg, "step") == 0) tb = RawReader::STEP;
+					else if(strcmp(optarg, "user") == 0) tb = RawReader::USER;
+					else { fprintf(stderr, "ERROR: unkown timebase '%s'\n", optarg); exit(1); }
+					break;
+
 			default:	displayUsage(argv[0]); exit(1);
 			}
 		}
@@ -111,7 +122,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	RawReader *reader = RawReader::openFile(inputFilePrefix);
+	RawReader *reader = RawReader::openFile(inputFilePrefix, tb);
 	
 	// If data was taken in ToT mode, do not attempt to load these files
 	unsigned long long mask = SystemConfig::LOAD_ALL;

--- a/src/petsys_util/convert_raw_to_raw.cpp
+++ b/src/petsys_util/convert_raw_to_raw.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	
-	RawReader *reader = RawReader::openFile(inputFilePrefix);
+	RawReader *reader = RawReader::openFile(inputFilePrefix, RawReader::SYNC);
 	
 	DataFileWriter *dataFileWriter = new DataFileWriter(outputFileName, 0, RAW, fileType , 0, eventFractionToWrite, fileSplitTime);
 

--- a/src/petsys_util/convert_raw_to_singles.cpp
+++ b/src/petsys_util/convert_raw_to_singles.cpp
@@ -27,7 +27,7 @@ void displayHelp(char * program)
 	fprintf(stderr,  "  --writeRoot \t\t Set the output data format to ROOT TTree\n");
 	fprintf(stderr,  "  --writeFraction N \t\t Fraction of events to write. Default: 100%%.\n");
 	fprintf(stderr,  "  --splitTime t \t\t Split output into different files every t seconds.\n");
-	fprintf(stderr,  "  --timebase [sync|wall|step|user] \t\t Select timebase for written data\n");
+	fprintf(stderr,  "  --timeref [sync|wall|step|user] \t\t Select timeref for written data\n");
 	fprintf(stderr,  "  --help \t\t Show this help message and exit \n");	
 	
 };
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 	FILE_TYPE fileType = FILE_TEXT;
 	long long eventFractionToWrite = 1024;
 	double fileSplitTime = 0.0;
-	RawReader::timebase_t tb = RawReader::SYNC;
+	RawReader::timeref_t tb = RawReader::SYNC;
 
 
 	static struct option longOptions[] = {
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 		{ "writeRoot", no_argument, 0, 0 },
 		{ "writeFraction", required_argument, 0, 0},
 		{ "splitTime", required_argument, 0, 0},
-		{ "timebase", required_argument, 0, 0}
+		{ "timeref", required_argument, 0, 0}
 	};
 
 	while(true) {
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 					else if(strcmp(optarg, "wall") == 0) tb = RawReader::WALL;
 					else if(strcmp(optarg, "step") == 0) tb = RawReader::STEP;
 					else if(strcmp(optarg, "user") == 0) tb = RawReader::USER;
-					else { fprintf(stderr, "ERROR: unkown timebase '%s'\n", optarg); exit(1); }
+					else { fprintf(stderr, "ERROR: unkown timeref '%s'\n", optarg); exit(1); }
 					break;
 
 			default:	displayUsage(argv[0]); exit(1);

--- a/src/petsys_util/convert_raw_to_singles.cpp
+++ b/src/petsys_util/convert_raw_to_singles.cpp
@@ -27,6 +27,7 @@ void displayHelp(char * program)
 	fprintf(stderr,  "  --writeRoot \t\t Set the output data format to ROOT TTree\n");
 	fprintf(stderr,  "  --writeFraction N \t\t Fraction of events to write. Default: 100%%.\n");
 	fprintf(stderr,  "  --splitTime t \t\t Split output into different files every t seconds.\n");
+	fprintf(stderr,  "  --timebase [sync|wall|step|user] \t\t Select timebase for written data\n");
 	fprintf(stderr,  "  --help \t\t Show this help message and exit \n");	
 	
 };
@@ -39,11 +40,12 @@ void displayUsage(char *argv0)
 int main(int argc, char *argv[])
 {
 	char *configFileName = NULL;
-    char *inputFilePrefix = NULL;
-    char *outputFileName = NULL;
+	char *inputFilePrefix = NULL;
+	char *outputFileName = NULL;
 	FILE_TYPE fileType = FILE_TEXT;
 	long long eventFractionToWrite = 1024;
 	double fileSplitTime = 0.0;
+	RawReader::timebase_t tb = RawReader::SYNC;
 
 
 	static struct option longOptions[] = {
@@ -52,7 +54,8 @@ int main(int argc, char *argv[])
 		{ "writeBinary", no_argument, 0, 0 },
 		{ "writeRoot", no_argument, 0, 0 },
 		{ "writeFraction", required_argument, 0, 0},
-		{ "splitTime", required_argument, 0, 0}	
+		{ "splitTime", required_argument, 0, 0},
+		{ "timebase", required_argument, 0, 0}
 	};
 
 	while(true) {
@@ -76,6 +79,14 @@ int main(int argc, char *argv[])
 			case 3:		fileType = FILE_ROOT; break;
 			case 4:		eventFractionToWrite = round(1024 *boost::lexical_cast<float>(optarg) / 100.0); break;
 			case 5:		fileSplitTime = boost::lexical_cast<double>(optarg); break;
+
+			case 6:		if(strcmp(optarg, "sync") == 0) tb = RawReader::SYNC;
+					else if(strcmp(optarg, "wall") == 0) tb = RawReader::WALL;
+					else if(strcmp(optarg, "step") == 0) tb = RawReader::STEP;
+					else if(strcmp(optarg, "user") == 0) tb = RawReader::USER;
+					else { fprintf(stderr, "ERROR: unkown timebase '%s'\n", optarg); exit(1); }
+					break;
+
 			default:	displayUsage(argv[0]); exit(1);
 			}
 		}
@@ -99,7 +110,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	RawReader *reader = RawReader::openFile(inputFilePrefix);
+	RawReader *reader = RawReader::openFile(inputFilePrefix, tb);
 	
 	// If data was taken in ToT mode, do not attempt to load these files
 	unsigned long long mask = SystemConfig::LOAD_ALL;

--- a/src/raw_data/RawReader.cpp
+++ b/src/raw_data/RawReader.cpp
@@ -54,7 +54,7 @@ RawReader::~RawReader()
 	if(indexFile != NULL) fclose(indexFile);
 }
 
-RawReader *RawReader::openFile(const char *fnPrefix, timebase_t tb)
+RawReader *RawReader::openFile(const char *fnPrefix, timeref_t tb)
 {
 	RawReader *reader = new RawReader();
 

--- a/src/raw_data/RawReader.hpp
+++ b/src/raw_data/RawReader.hpp
@@ -14,7 +14,7 @@ namespace PETSYS {
 
 	class RawReader : public EventStream {
 	public:
-		enum timebase_t {
+		enum timeref_t {
 			SYNC,
 			WALL,
 			STEP,
@@ -40,7 +40,7 @@ namespace PETSYS {
 
 	public:
 		~RawReader();
-		static RawReader *openFile(const char *fnPrefix, timebase_t tb);
+		static RawReader *openFile(const char *fnPrefix, timeref_t tb);
 		bool isQDC(unsigned int gChannelID);
 		bool isTOT();
 		double getFrequency();
@@ -74,7 +74,7 @@ namespace PETSYS {
 		bool qdcMode[MAX_NUMBER_CHANNELS];		
 		int triggerID;
 
-		timebase_t tb;
+		timeref_t tb;
 		double daqSynchronizationEpoch;
 		unsigned long long fileCreationDAQTime;
 

--- a/src/raw_data/RawReader.hpp
+++ b/src/raw_data/RawReader.hpp
@@ -13,6 +13,14 @@ static const unsigned MAX_NUMBER_CHANNELS = 4194304;
 namespace PETSYS {
 
 	class RawReader : public EventStream {
+	public:
+		enum timebase_t {
+			SYNC,
+			WALL,
+			STEP,
+			USER
+		};
+
 	private:
 		struct UndecodedHit {
 			u_int64_t frameID;
@@ -32,7 +40,7 @@ namespace PETSYS {
 
 	public:
 		~RawReader();
-		static RawReader *openFile(const char *fnPrefix);
+		static RawReader *openFile(const char *fnPrefix, timebase_t tb);
 		bool isQDC(unsigned int gChannelID);
 		bool isTOT();
 		double getFrequency();
@@ -44,7 +52,6 @@ namespace PETSYS {
 
 	private:
 		RawReader();
-		void processRange(unsigned long begin, unsigned long end, bool verbose, EventSink<RawHit> *pipeline);
 
 		FILE *indexFile;
 		bool indexIsTemp;
@@ -52,6 +59,7 @@ namespace PETSYS {
 		float stepValue1, stepValue2;
 		unsigned long long stepBegin;
 		unsigned long long stepEnd;
+		unsigned long long stepFirstFrameID;
 		unsigned long long getStepBegin();
 		unsigned long long getStepEnd();
 
@@ -65,8 +73,11 @@ namespace PETSYS {
 		unsigned frequency;
 		bool qdcMode[MAX_NUMBER_CHANNELS];		
 		int triggerID;
-		
-		
+
+		timebase_t tb;
+		double daqSynchronizationEpoch;
+		unsigned long long fileCreationDAQTime;
+
 	};
 }
 

--- a/src/raw_data/write_raw.cpp
+++ b/src/raw_data/write_raw.cpp
@@ -54,7 +54,7 @@ public:
     void writeCurrentDataBuffer(bool resetSize = false);
 	void swapBuffers();
 	size_t getBufferSize(){return BUFFER_SIZE;}
-	void writeHeader(double acquisitionStartTime, long systemFrequency, char *mode, int triggerID);
+	void writeHeader(unsigned long long fileCreationDAQTime, double daqSynchronizationEpoch, long systemFrequency, char *mode, int triggerID);
 	void writeCalibrationData(CalibrationData c);
 	void setAcqModeToCalibration(){acqStdMode = false;}
 	long long getCurrentPosition(){
@@ -176,16 +176,17 @@ void DataWriter::swapBuffers() {
 }
 
 
-void DataWriter::writeHeader(double acquisitionStartTime, long systemFrequency, char *mode, int triggerID) {
+void DataWriter::writeHeader(unsigned long long fileCreationDAQTime, double daqSynchronizationEpoch, long systemFrequency, char *mode, int triggerID) {
 	bool qdcMode = (strcmp(mode, "qdc") == 0);
 	uint64_t header[8];
 	for(int i = 0; i < 8; i++)
 		header[i] = 0;
 	header[0] |= uint32_t(systemFrequency);
 	header[0] |= (qdcMode ? 0x1UL : 0x0UL) << 32;
-	memcpy(header+1, &acquisitionStartTime, sizeof(double));
+	memcpy(header+1, &daqSynchronizationEpoch, sizeof(double));
 	if (triggerID != -1) { header[2] = 0x8000 + triggerID; }
 	if (strcmp(mode, "mixed") == 0) { header[3] = 0x1UL; }
+	header[4] = fileCreationDAQTime;
 
 	Buffer& currentBuffer = buffers[currentBufferIndex];
 
@@ -244,9 +245,10 @@ int main(int argc, char *argv[])
 	char *outputFilePrefix = argv[2];
 	long systemFrequency = boost::lexical_cast<long>(argv[3]);
 	bool qdcMode = (strcmp(argv[4], "qdc") == 0);
-	double acquisitionStartTime = boost::lexical_cast<double>(argv[5]);
-	bool acqStdMode = (argv[6][0] == 'N');
-	int triggerID = boost::lexical_cast<int>(argv[7]);
+	double daqSynchronizationEpoch = boost::lexical_cast<double>(argv[5]);
+	unsigned long long fileCreationDAQTime = boost::lexical_cast<unsigned long long>(argv[6]);
+	bool acqStdMode = (argv[7][0] == 'N');
+	int triggerID = boost::lexical_cast<int>(argv[8]);
 
 	PETSYS::SHM_RAW *shm = new PETSYS::SHM_RAW(shmObjectPath);
 
@@ -285,7 +287,7 @@ int main(int argc, char *argv[])
 
 	fprintf(stderr, "INFO: Writing data to '%s.rawf' and index to '%s.idxf'\n", outputFilePrefix, outputFilePrefix);
 
-	writer.writeHeader(acquisitionStartTime, systemFrequency, argv[4], triggerID);
+	writer.writeHeader(fileCreationDAQTime, daqSynchronizationEpoch, systemFrequency, argv[4], triggerID);
 
 	CalibrationPool calibrationPool(shm);
 
@@ -312,34 +314,38 @@ int main(int argc, char *argv[])
 
 	while(fread(&blockHeader, sizeof(blockHeader), 1, stdin) == 1) {
 
+		unsigned bs = shm->getSizeInFrames();
+		unsigned rdPointer = blockHeader.rdPointer % (2*bs);
+		unsigned wrPointer = blockHeader.wrPointer % (2*bs);
+
 		step1 = blockHeader.step1;
 		step2 = blockHeader.step2;
 
 		if(blockHeader.blockType == 0) {
 			// First block in a step
+			unsigned index = rdPointer % bs;
+
 			stepAllFrames = 0;
 			stepEvents = 0;
 			stepMaxFrame = 0;
 			stepLostFramesN = 0;
 			stepLostFrames0 = 0;
-			lastFrameID = -1;
-			stepFirstFrameID = -1;
+
+			stepFirstFrameID = shm->getFrameID(index);
+			lastFrameID = stepFirstFrameID - 1;
 			lastFrameType = FRAME_TYPE_UNKNOWN;
 
 			if(!acqStdMode) calibrationPool.clear();
 
 			stepStartOffset = writer.getCurrentPosition();
 
-			r = fprintf(tempFile, "%f\t%f\t%ld\t", blockHeader.step1, blockHeader.step2, stepStartOffset);
+			r = fprintf(tempFile, "%f\t%f\t%ld\t%ld\t", blockHeader.step1, blockHeader.step2, stepStartOffset, stepFirstFrameID);
 			if(r < 0) { fprintf(stderr, "ERROR writing to %s: %d %s\n", fNameRaw, errno, strerror(errno)); exit(1); }
 			r = fflush(tempFile);
 			if(r != 0) { fprintf(stderr, "ERROR writing to %s: %d %s\n", fNameRaw, errno, strerror(errno)); exit(1); }
 
 		}
 		
-		unsigned bs = shm->getSizeInFrames();
-		unsigned rdPointer = blockHeader.rdPointer % (2*bs);
-		unsigned wrPointer = blockHeader.wrPointer % (2*bs);
 
 		if(!acqStdMode) calibrationPool.processBatch(rdPointer, wrPointer);
 
@@ -347,7 +353,6 @@ int main(int argc, char *argv[])
 			unsigned index = rdPointer % bs;
 			
 			long long frameID = shm->getFrameID(index);
-			if(stepFirstFrameID == -1) stepFirstFrameID = frameID;
 			if(frameID <= lastFrameID) {
 				fprintf(stderr, "WARNING!! Frame ID reversal: %12lld -> %12lld | %04u %04u %04u\n", 
 					lastFrameID, frameID, 
@@ -355,7 +360,7 @@ int main(int argc, char *argv[])
 					);
 				
 			}
-			else if ((lastFrameID >= 0) && (frameID != (lastFrameID + 1))) {
+			else if (frameID != (lastFrameID + 1)) {
 				// We have skipped one or more frame ID, so 
 				// we account them as lost...
 				long long skippedFrames = (frameID - lastFrameID) - 1;
@@ -410,12 +415,12 @@ int main(int argc, char *argv[])
 			}
 
 			// Do not write sequences of normal empty frames, unless we're closing a step
-			if(blockHeader.blockType == 1 && lastFrameType == FRAME_TYPE_ZERO_DATA && frameType == lastFrameType) {
+			if(blockHeader.blockType != 2 && lastFrameType == FRAME_TYPE_ZERO_DATA && frameType == lastFrameType) {
 				continue;
 			}
 
 			// Do not write sequences of all lost frames, unless we're closing a step
-			if(blockHeader.blockType == 1 && lastFrameType == FRAME_TYPE_ALL_LOST && frameType == lastFrameType) {
+			if(blockHeader.blockType != 2 && lastFrameType == FRAME_TYPE_ALL_LOST && frameType == lastFrameType) {
 				continue;
 			}
 			lastFrameType = frameType;


### PR DESCRIPTION
* acquire_sipm_data* --wait-on fifo_file_name
Initializes system but waits for a byte to be written to the named pipe before opening the raw data file and actually  acquiring data.
 The named pipe must created before with mkfifo (or os.mkfifo in Python).

* convert_raw_to_* --timebase sync|wall|step|user
Chooses the time reference for the output files.
- sync (default): 0 is system synchronization
-wall: 0 is UNIX epoch
- step: 0 is start of step
- user: 0 is opening of data data file
