### PR TITLE
Fix getBiasSlotinfo function (missing functionality)

### DIFF
--- a/src/petsys_py_lib/daqd.py
+++ b/src/petsys_py_lib/daqd.py
@@ -185,6 +185,7 @@ class Connection:
 		return sorted(self.__activeBiasSlots.keys())
 
 	def getBiasSlotInfo(self, portID, slaveID, slotID):
+		if self.__activeUnits == {}: self.__scanUnits_ll()
 		return self.__activeBiasSlots[(portID, slaveID, slotID)]
 
 	def getActiveBiasChannels(self):


### PR DESCRIPTION
getBiasSlotinfo() would return nothing if system not initialized. Copied behaviour from similar functions.